### PR TITLE
products-delete-function

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :show, :edit]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :authenticate_user!, only: [:new, :edit]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index
     @items = Item.order("created_at DESC")
@@ -23,20 +23,25 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    if user_signed_in? && @item.present?
-      if current_user.id == @item.user_id
-        render :edit
-      else
-        redirect_to :index
-      end
+    if current_user.id == @item.user_id
+      render :edit
+    else
+      redirect_to root_path
     end
   end
 
   def update
     if @item.update(item_params)
-      redirect_to item_path
+      redirect_to item_path(@item)
     else
       render :edit
+    end
+  end
+
+  def destroy
+    if current_user.id == @item.user_id
+      @item.destroy
+      redirect_to root_path
     end
   end
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
     <% if current_user.id == @item.user_id %>
       <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <%= link_to "削除", "/items/#{@item.id}", method: :delete, class:"item-destroy" %>
     <% else %>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy]
 end


### PR DESCRIPTION
# what
## 商品削除機能の実装。ログインユーザーが商品を削除したい場合に使用できるような実装を行なっている。

# why
## 商品が何かしらの影響で壊れたり知り合いに売却した等の理由で商品を売却できないとなったときに商品を残していては購入希望者等が間違えて購入してしまう可能性がある。そのリスクを防ぐため。

商品削除の画像[https://gyazo.com/17fd47c9b698e4dee9dd3aef724a2b18](url)

なお、メンターにお聞きした際に現在のコードでも大丈夫だが、直していてもいいところを指摘していただいたため少しだけ修正を加えている。なお、挙動は問題なく動いており確認済みであります。